### PR TITLE
Text::CSV::Encoded::Coder::EncodeGuess dies on utf-8 data

### DIFF
--- a/lib/Text/CSV/Encoded/Coder/EncodeGuess.pm
+++ b/lib/Text/CSV/Encoded/Coder/EncodeGuess.pm
@@ -35,6 +35,7 @@ sub decode_fields_ref {
         for ( @$arrayref ) {
             my $enc = Encode::Guess::guess_encoding( $_, @$encoding );
             $enc = $self->find_encoding( $encoding->[0] ) unless ref $enc;
+            next if ($enc->name() eq 'utf8' and $self->{automatic_UTF8});
             $_ = $enc->decode( $_, $self->decode_check_value );
         }
     }

--- a/t/pp_05_guess.t
+++ b/t/pp_05_guess.t
@@ -9,7 +9,7 @@ use lib qw(./t);
 use _setup;
 
 BEGIN {
-    _setup->tests(6);
+    _setup->tests(8);
 }
 
 

--- a/t/tests/05_guess.t
+++ b/t/tests/05_guess.t
@@ -26,5 +26,11 @@ is( join('', $csv->fields), 'これはEUC-JP' );
 ok( $csv->parse( Encode::encode('shiftjis', 'これはShift_JIS') ) );
 is( join('', $csv->fields), 'これはShift_JIS' );
 
+
+$csv->encoding( ['utf-8', 'cp1252'] );
+$csv->encoding_out( 'utf-8' );
+ok( $csv->combine(map {Encode::encode('utf-8', $_)} qw(cow says… möo)) );
+is( $csv->string, Encode::encode('utf-8', 'cow,"says…",möo'));
+
 1;
 


### PR DESCRIPTION
Hello!

::EncodeGuess now dies on utf8 input due to the recent Text::CSV auto-utf8 changes.  This patch avoids double-decoding by skipping it when the encoder is guessed to be utf8 and the automatic_UTF8 flag is set.  I've also added a test to 05_guess.t.

Thank you for your work on this module and have a great day!

Cheers,
Fitz

-- commit message below --
- Recent versions of Text::CSV_{XS,PP} now automatically decode utf-8
  strings.  ::EncodeGuess wasn't paying attention to this and
  attempting to doubly-decode utf-8 strings, causing the fatal error:
  "Cannot decode string with wide character".  This patch skips the
  decode when the utf8 encoder is guessed and the automatic_UTF8 flag
  is set.
  - add utf8 test to t/tests/05_guess.t
