### PR TITLE
fix 03_file.t

### DIFF
--- a/t/tests/03_file.t
+++ b/t/tests/03_file.t
@@ -105,7 +105,7 @@ $csv->encoding( undef );
 while( 1 ) {
     my $row = $csv->getline( $fh );
     $csv->eof and last;
-    is( $row->[0], Encode::decode_utf8( $checker->getline( $fh2 )->[1] ) );
+    is( $row->[0], $checker->getline( $fh2 )->[1] );
 }
 
 close($fh);


### PR DESCRIPTION
The latest version of Text::CSV_XS & Text::CSV_PP returns utf8 flagged string when parsing utf8 string even if the given string is not utf8 flagged.
